### PR TITLE
Add `after` and `afterNow` as aliases to `from` and `fromNow`

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,10 +72,13 @@ N.prototype.from = function (date) {
     return new Date(date.getTime() + this.n);
 }
 
+N.prototype.after = N.prototype.from;
+
 N.prototype.fromNow = function () {
     return this.from(new Date());
 }
 
+N.prototype.afterNow = N.prototype.fromNow
 
 N.prototype.before = function (date) {
     return new Date(date.getTime() - this.n);

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ N.prototype.fromNow = function () {
     return this.from(new Date());
 }
 
-N.prototype.afterNow = N.prototype.fromNow
+N.prototype.afterNow = N.prototype.fromNow;
 
 N.prototype.before = function (date) {
     return new Date(date.getTime() - this.n);


### PR DESCRIPTION
I constantly try to do so, always to be reminded it's not a thing.

Edit: especially in test code like this:

```js
const now = new Date()
const startTime = T(3).minutes().before(now).valueOf()
const endTime = T(3).minutes().from(now).valueOf()
const beforeStart = T(5).minutes().before(now).valueOf()
const afterStart = T(5).minutes().after(now).valueOf()
````

Note how I even have a bug in there as we speak, having used `after` instead of `from`.